### PR TITLE
Add test for clarity-bitcoin-v5 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+tests/** linguist-vendored
+vitest.config.js linguist-vendored
+* text=lf

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ yarn-error.log*
 
 # Optional test coverage directory
 .nyc_output/
+
+**/settings/Mainnet.toml
+**/settings/Testnet.toml
+.cache/**
+history.txt

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -12,4 +12,4 @@ requirements = [
 [repl.remote_data]
 enabled = true
 api_url = "https://api.hiro.so"
-initial_height = 586956
+initial_height = 581021

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,0 +1,15 @@
+[project]
+name = "bitcoin-tx-proof"
+description = ""
+authors = []
+telemetry = true
+cache_dir = "./.cache"
+
+requirements = [
+    { contract_id = 'SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.clarity-bitcoin-lib-v5' },
+]
+
+[repl.remote_data]
+enabled = true
+api_url = "https://api.hiro.so"
+initial_height = 586956

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -12,4 +12,4 @@ requirements = [
 [repl.remote_data]
 enabled = true
 api_url = "https://api.hiro.so"
-initial_height = 581021
+initial_height = 595050

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -1,0 +1,49 @@
+---
+id: 0
+name: "Simulated deployment, used as a default for `clarinet console`, `clarinet test` and `clarinet check`"
+network: simnet
+genesis:
+  wallets:
+    - name: deployer
+      address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+      balance: "100000000000000"
+    - name: faucet
+      address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+      balance: "100000000000000"
+    - name: wallet_1
+      address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+      balance: "100000000000000"
+    - name: wallet_2
+      address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+      balance: "100000000000000"
+    - name: wallet_3
+      address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+      balance: "100000000000000"
+    - name: wallet_4
+      address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+      balance: "100000000000000"
+    - name: wallet_5
+      address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+      balance: "100000000000000"
+    - name: wallet_6
+      address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+      balance: "100000000000000"
+    - name: wallet_7
+      address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+      balance: "100000000000000"
+    - name: wallet_8
+      address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+      balance: "100000000000000"
+  contracts:
+    - costs
+    - pox
+    - pox-2
+    - pox-3
+    - pox-4
+    - lockup
+    - costs-2
+    - costs-3
+    - cost-voting
+    - bns
+plan:
+  batches: []

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "bitcoin-tx-proof",
   "version": "1.0.0",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
     "btxproof": "dist/cli.js"
   },
   "scripts": {
+    "test:stacks": "vitest run",
     "test": "jest",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write \"src/**/*.ts\"",
@@ -18,20 +20,38 @@
   },
   "dependencies": {
     "axios": "^1.6.7",
-    "bitcoinjs-lib": "^6.1.5",
     "axios-rate-limit": "^1.3.0",
+    "bitcoinjs-lib": "^6.1.5",
     "node-cache": "^5.1.2"
   },
   "devDependencies": {
-    "@types/node": "^20.11.19",
-    "@types/jest": "^29.5.0",
+    "@clarigen/core": "^2.1.2",
+    "@clarigen/test": "^2.1.2",
+    "@hirosystems/clarinet-sdk": "2.13.0-beta17",
     "@jest/types": "^29.5.0",
-    "typescript": "^5.3.3",
+    "@stacks/transactions": "^6.12.0",
+    "@types/jest": "^29.5.0",
+    "@types/node": "^20.11.19",
+    "@types/node-cache": "^4.2.5",
+    "@vitest/expect": "1.6.0",
+    "chokidar-cli": "^3.0.0",
+    "eslint": "^8.0.0",
     "jest": "^29.5.0",
+    "prettier": "^2.8.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.2",
-    "eslint": "^8.0.0",
-    "prettier": "^2.8.0",
-    "@types/node-cache": "^4.2.5"
+    "typescript": "^5.3.3",
+    "vite": "^6.1.0",
+    "vitest": "1.6.0",
+    "vitest-environment-clarinet": "^2.1.0"
+  },
+  "engines": {
+    "node": "22.13"
+  },
+  "pnpm": {
+    "overrides": {
+      "@hirosystems/clarinet-sdk": "2.13.0-beta17",
+      "@hirosystems/clarinet-sdk-wasm": "2.13.0-beta17"
+    }
   }
 }

--- a/settings/Devnet.toml
+++ b/settings/Devnet.toml
@@ -1,0 +1,158 @@
+[network]
+name = "devnet"
+deployment_fee_rate = 10
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+balance = 100_000_000_000_000
+# secret_key: 753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601
+# stx_address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+# btc_address: mqVnk6NPRdhntvfm4hh9vvjiRkFDUuSYsH
+
+[accounts.wallet_1]
+mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
+balance = 100_000_000_000_000
+# secret_key: 7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c17801
+# stx_address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+# btc_address: mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC
+
+[accounts.wallet_2]
+mnemonic = "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital"
+balance = 100_000_000_000_000
+# secret_key: 530d9f61984c888536871c6573073bdfc0058896dc1adfe9a6a10dfacadc209101
+# stx_address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+# btc_address: muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG
+
+[accounts.wallet_3]
+mnemonic = "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high"
+balance = 100_000_000_000_000
+# secret_key: d655b2523bcd65e34889725c73064feb17ceb796831c0e111ba1a552b0f31b3901
+# stx_address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+# btc_address: mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7
+
+[accounts.wallet_4]
+mnemonic = "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin"
+balance = 100_000_000_000_000
+# secret_key: f9d7206a47f14d2870c163ebab4bf3e70d18f5d14ce1031f3902fbbc894fe4c701
+# stx_address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+# btc_address: mg1C76bNTutiCDV3t9nWhZs3Dc8LzUufj8
+
+[accounts.wallet_5]
+mnemonic = "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase"
+balance = 100_000_000_000_000
+# secret_key: 3eccc5dac8056590432db6a35d52b9896876a3d5cbdea53b72400bc9c2099fe801
+# stx_address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+# btc_address: mweN5WVqadScHdA81aATSdcVr4B6dNokqx
+
+[accounts.wallet_6]
+mnemonic = "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy"
+balance = 100_000_000_000_000
+# secret_key: 7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01
+# stx_address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+# btc_address: mzxXgV6e4BZSsz8zVHm3TmqbECt7mbuErt
+
+[accounts.wallet_7]
+mnemonic = "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow"
+balance = 100_000_000_000_000
+# secret_key: b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401
+# stx_address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+# btc_address: n37mwmru2oaVosgfuvzBwgV2ysCQRrLko7
+
+[accounts.wallet_8]
+mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
+balance = 100_000_000_000_000
+# secret_key: 6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01
+# stx_address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+# btc_address: n2v875jbJ4RjBnTjgbfikDfnwsDV5iUByw
+
+[accounts.faucet]
+mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+balance = 100_000_000_000_000
+# secret_key: de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b801
+# stx_address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+# btc_address: mjSrB3wS4xab3kYqFktwBzfTdPg367ZJ2d
+
+[devnet]
+disable_stacks_explorer = false
+disable_stacks_api = false
+# disable_postgres = false
+# disable_subnet_api = false
+# disable_bitcoin_explorer = true
+# working_dir = "tmp/devnet"
+# stacks_node_events_observers = ["host.docker.internal:8002"]
+# miner_mnemonic = "fragile loan twenty basic net assault jazz absorb diet talk art shock innocent float punch travel gadget embrace caught blossom hockey surround initial reduce"
+# miner_derivation_path = "m/44'/5757'/0'/0/0"
+# faucet_mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+# faucet_derivation_path = "m/44'/5757'/0'/0/0"
+# stacker_mnemonic = "empty lens any direct brother then drop fury rule pole win claim scissors list rescue horn rent inform relief jump sword weekend half legend"
+# stacker_derivation_path = "m/44'/5757'/0'/0/0"
+# orchestrator_port = 20445
+# bitcoin_node_p2p_port = 18444
+# bitcoin_node_rpc_port = 18443
+# bitcoin_node_username = "devnet"
+# bitcoin_node_password = "devnet"
+# bitcoin_controller_block_time = 30_000
+# stacks_node_rpc_port = 20443
+# stacks_node_p2p_port = 20444
+# stacks_api_port = 3999
+# stacks_api_events_port = 3700
+# bitcoin_explorer_port = 8001
+# stacks_explorer_port = 8000
+# postgres_port = 5432
+# postgres_username = "postgres"
+# postgres_password = "postgres"
+# postgres_database = "postgres"
+# bitcoin_node_image_url = "quay.io/hirosystems/bitcoind:26.0"
+# stacks_node_image_url = "quay.io/hirosystems/stacks-node:devnet-3.1"
+# stacks_signer_image_url = "quay.io/hirosystems/stacks-signer:devnet-3.1"
+# stacks_api_image_url = "hirosystems/stacks-blockchain-api:master"
+# stacks_explorer_image_url = "hirosystems/explorer:latest"
+# bitcoin_explorer_image_url = "quay.io/hirosystems/bitcoin-explorer:devnet"
+# postgres_image_url = "postgres:alpine"
+# enable_subnet_node = true
+# subnet_node_image_url = "hirosystems/stacks-subnets:0.8.1"
+# subnet_leader_mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+# subnet_leader_derivation_path = "m/44'/5757'/0'/0/0"
+# subnet_contract_id = "ST173JK7NZBA4BS05ZRATQH1K89YJMTGEH1Z5J52E.subnet-v3-0-1"
+# subnet_node_rpc_port = 30443
+# subnet_node_p2p_port = 30444
+# subnet_events_ingestion_port = 30445
+# subnet_node_events_observers = ["host.docker.internal:8002"]
+# subnet_api_image_url = "hirosystems/stacks-blockchain-api:master"
+# subnet_api_postgres_database = "subnet_api"
+
+# epoch_2_0 = 100
+# epoch_2_05 = 100
+# epoch_2_1 = 101
+# epoch_2_2 = 102
+# epoch_2_3 = 103
+# epoch_2_4 = 104
+# epoch_2_5 = 108
+# epoch_3_0 = 142
+# epoch_3_1 = 144
+
+# Send some stacking orders
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_1"
+slots = 2
+btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_2"
+slots = 2
+btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 1
+duration = 10
+auto_extend = true
+wallet = "wallet_3"
+slots = 2
+btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
+

--- a/src/__tests__/rpc.test.ts
+++ b/src/__tests__/rpc.test.ts
@@ -1,7 +1,6 @@
 import { BitcoinRPC } from '../rpc';
-import axios, { AxiosInstance, AxiosResponse, AxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import RateLimit from 'axios-rate-limit';
-import NodeCache from 'node-cache';
 
 jest.mock('axios');
 jest.mock('axios-rate-limit');

--- a/src/__vitests__/clarigen-types.ts
+++ b/src/__vitests__/clarigen-types.ts
@@ -1,0 +1,381 @@
+
+import type { TypedAbiArg, TypedAbiFunction, TypedAbiMap, TypedAbiVariable, Response } from '@clarigen/core';
+
+export const contracts = {
+  clarityBitcoinLibV5: {
+  "functions": {
+    boolListOfLen: {"name":"bool-list-of-len","access":"private","args":[{"name":"n","type":"uint128"}],"outputs":{"type":{"list":{"type":"bool","length":8}}}} as TypedAbiFunction<[n: TypedAbiArg<number | bigint, "n">], boolean[]>,
+    innerMerkleProofVerify: {"name":"inner-merkle-proof-verify","access":"private","args":[{"name":"ctr","type":"uint128"},{"name":"state","type":{"tuple":[{"name":"cur-hash","type":{"buffer":{"length":32}}},{"name":"path","type":"uint128"},{"name":"proof-hashes","type":{"list":{"type":{"buffer":{"length":32}},"length":14}}},{"name":"root-hash","type":{"buffer":{"length":32}}},{"name":"tree-depth","type":"uint128"},{"name":"verified","type":"bool"}]}}],"outputs":{"type":{"tuple":[{"name":"cur-hash","type":{"buffer":{"length":32}}},{"name":"path","type":"uint128"},{"name":"proof-hashes","type":{"list":{"type":{"buffer":{"length":32}},"length":14}}},{"name":"root-hash","type":{"buffer":{"length":32}}},{"name":"tree-depth","type":"uint128"},{"name":"verified","type":"bool"}]}}} as TypedAbiFunction<[ctr: TypedAbiArg<number | bigint, "ctr">, state: TypedAbiArg<{
+  "curHash": Uint8Array;
+  "path": number | bigint;
+  "proofHashes": Uint8Array[];
+  "rootHash": Uint8Array;
+  "treeDepth": number | bigint;
+  "verified": boolean;
+}, "state">], {
+  "curHash": Uint8Array;
+  "path": bigint;
+  "proofHashes": Uint8Array[];
+  "rootHash": Uint8Array;
+  "treeDepth": bigint;
+  "verified": boolean;
+}>,
+    reverseBuff16: {"name":"reverse-buff16","access":"private","args":[{"name":"input","type":{"buffer":{"length":16}}}],"outputs":{"type":{"buffer":{"length":17}}}} as TypedAbiFunction<[input: TypedAbiArg<Uint8Array, "input">], Uint8Array>,
+    wasTxMinedInternal: {"name":"was-tx-mined-internal","access":"private","args":[{"name":"height","type":"uint128"},{"name":"tx","type":{"buffer":{"length":4096}}},{"name":"header","type":{"buffer":{"length":80}}},{"name":"merkle-root","type":{"buffer":{"length":32}}},{"name":"proof","type":{"tuple":[{"name":"hashes","type":{"list":{"type":{"buffer":{"length":32}},"length":14}}},{"name":"tree-depth","type":"uint128"},{"name":"tx-index","type":"uint128"}]}}],"outputs":{"type":{"response":{"ok":{"buffer":{"length":32}},"error":"uint128"}}}} as TypedAbiFunction<[height: TypedAbiArg<number | bigint, "height">, tx: TypedAbiArg<Uint8Array, "tx">, header: TypedAbiArg<Uint8Array, "header">, merkleRoot: TypedAbiArg<Uint8Array, "merkleRoot">, proof: TypedAbiArg<{
+  "hashes": Uint8Array[];
+  "treeDepth": number | bigint;
+  "txIndex": number | bigint;
+}, "proof">], Response<Uint8Array, bigint>>,
+    getBcHHash: {"name":"get-bc-h-hash","access":"read_only","args":[{"name":"bh","type":"uint128"}],"outputs":{"type":{"optional":{"buffer":{"length":32}}}}} as TypedAbiFunction<[bh: TypedAbiArg<number | bigint, "bh">], Uint8Array | null>,
+    getCommitmentScriptPubKey: {"name":"get-commitment-scriptPubKey","access":"read_only","args":[{"name":"outs","type":{"list":{"type":{"tuple":[{"name":"scriptPubKey","type":{"buffer":{"length":128}}},{"name":"value","type":"uint128"}]},"length":8}}}],"outputs":{"type":{"buffer":{"length":128}}}} as TypedAbiFunction<[outs: TypedAbiArg<{
+  "scriptPubKey": Uint8Array;
+  "value": number | bigint;
+}[], "outs">], Uint8Array>,
+    getReversedTxid: {"name":"get-reversed-txid","access":"read_only","args":[{"name":"tx","type":{"buffer":{"length":4096}}}],"outputs":{"type":{"buffer":{"length":32}}}} as TypedAbiFunction<[tx: TypedAbiArg<Uint8Array, "tx">], Uint8Array>,
+    getTxid: {"name":"get-txid","access":"read_only","args":[{"name":"tx","type":{"buffer":{"length":4096}}}],"outputs":{"type":{"buffer":{"length":32}}}} as TypedAbiFunction<[tx: TypedAbiArg<Uint8Array, "tx">], Uint8Array>,
+    innerGetCommitmentScriptPubKey: {"name":"inner-get-commitment-scriptPubKey","access":"read_only","args":[{"name":"out","type":{"tuple":[{"name":"scriptPubKey","type":{"buffer":{"length":128}}},{"name":"value","type":"uint128"}]}},{"name":"result","type":{"buffer":{"length":128}}}],"outputs":{"type":{"buffer":{"length":128}}}} as TypedAbiFunction<[out: TypedAbiArg<{
+  "scriptPubKey": Uint8Array;
+  "value": number | bigint;
+}, "out">, result: TypedAbiArg<Uint8Array, "result">], Uint8Array>,
+    isBitSet: {"name":"is-bit-set","access":"read_only","args":[{"name":"val","type":"uint128"},{"name":"bit","type":"uint128"}],"outputs":{"type":"bool"}} as TypedAbiFunction<[val: TypedAbiArg<number | bigint, "val">, bit: TypedAbiArg<number | bigint, "bit">], boolean>,
+    isCommitmentPattern: {"name":"is-commitment-pattern","access":"read_only","args":[{"name":"scriptPubKey","type":{"buffer":{"length":128}}}],"outputs":{"type":"bool"}} as TypedAbiFunction<[scriptPubKey: TypedAbiArg<Uint8Array, "scriptPubKey">], boolean>,
+    parseBlockHeader: {"name":"parse-block-header","access":"read_only","args":[{"name":"headerbuff","type":{"buffer":{"length":80}}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"merkle-root","type":{"buffer":{"length":32}}},{"name":"nbits","type":"uint128"},{"name":"nonce","type":"uint128"},{"name":"parent","type":{"buffer":{"length":32}}},{"name":"timestamp","type":"uint128"},{"name":"version","type":"uint128"}]},"error":"uint128"}}}} as TypedAbiFunction<[headerbuff: TypedAbiArg<Uint8Array, "headerbuff">], Response<{
+  "merkleRoot": Uint8Array;
+  "nbits": bigint;
+  "nonce": bigint;
+  "parent": Uint8Array;
+  "timestamp": bigint;
+  "version": bigint;
+}, bigint>>,
+    parseTx: {"name":"parse-tx","access":"read_only","args":[{"name":"tx","type":{"buffer":{"length":4096}}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ins","type":{"list":{"type":{"tuple":[{"name":"outpoint","type":{"tuple":[{"name":"hash","type":{"buffer":{"length":32}}},{"name":"index","type":"uint128"}]}},{"name":"scriptSig","type":{"buffer":{"length":256}}},{"name":"sequence","type":"uint128"}]},"length":8}}},{"name":"locktime","type":"uint128"},{"name":"outs","type":{"list":{"type":{"tuple":[{"name":"scriptPubKey","type":{"buffer":{"length":128}}},{"name":"value","type":"uint128"}]},"length":8}}},{"name":"version","type":"uint128"}]},"error":"uint128"}}}} as TypedAbiFunction<[tx: TypedAbiArg<Uint8Array, "tx">], Response<{
+  "ins": {
+  "outpoint": {
+  "hash": Uint8Array;
+  "index": bigint;
+};
+  "scriptSig": Uint8Array;
+  "sequence": bigint;
+}[];
+  "locktime": bigint;
+  "outs": {
+  "scriptPubKey": Uint8Array;
+  "value": bigint;
+}[];
+  "version": bigint;
+}, bigint>>,
+    parseWtx: {"name":"parse-wtx","access":"read_only","args":[{"name":"tx","type":{"buffer":{"length":4096}}},{"name":"calculate-txid","type":"bool"}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ins","type":{"list":{"type":{"tuple":[{"name":"outpoint","type":{"tuple":[{"name":"hash","type":{"buffer":{"length":32}}},{"name":"index","type":"uint128"}]}},{"name":"scriptSig","type":{"buffer":{"length":256}}},{"name":"sequence","type":"uint128"}]},"length":8}}},{"name":"locktime","type":"uint128"},{"name":"outs","type":{"list":{"type":{"tuple":[{"name":"scriptPubKey","type":{"buffer":{"length":128}}},{"name":"value","type":"uint128"}]},"length":8}}},{"name":"segwit-marker","type":"uint128"},{"name":"segwit-version","type":"uint128"},{"name":"txid","type":{"optional":{"buffer":{"length":32}}}},{"name":"version","type":"uint128"},{"name":"witnesses","type":{"list":{"type":{"list":{"type":{"buffer":{"length":128}},"length":8}},"length":8}}}]},"error":"uint128"}}}} as TypedAbiFunction<[tx: TypedAbiArg<Uint8Array, "tx">, calculateTxid: TypedAbiArg<boolean, "calculateTxid">], Response<{
+  "ins": {
+  "outpoint": {
+  "hash": Uint8Array;
+  "index": bigint;
+};
+  "scriptSig": Uint8Array;
+  "sequence": bigint;
+}[];
+  "locktime": bigint;
+  "outs": {
+  "scriptPubKey": Uint8Array;
+  "value": bigint;
+}[];
+  "segwitMarker": bigint;
+  "segwitVersion": bigint;
+  "txid": Uint8Array | null;
+  "version": bigint;
+  "witnesses": Uint8Array[][];
+}, bigint>>,
+    readHashslice: {"name":"read-hashslice","access":"read_only","args":[{"name":"old-ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"hashslice","type":{"buffer":{"length":32}}}]},"error":"uint128"}}}} as TypedAbiFunction<[oldCtx: TypedAbiArg<{
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+}, "oldCtx">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "hashslice": Uint8Array;
+}, bigint>>,
+    readNextItem: {"name":"read-next-item","access":"read_only","args":[{"name":"ignored","type":"bool"},{"name":"result","type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"items","type":{"list":{"type":{"buffer":{"length":128}},"length":8}}}]},"error":"uint128"}}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"items","type":{"list":{"type":{"buffer":{"length":128}},"length":8}}}]},"error":"uint128"}}}} as TypedAbiFunction<[ignored: TypedAbiArg<boolean, "ignored">, result: TypedAbiArg<Response<{
+  "ctx": {
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+};
+  "items": Uint8Array[];
+}, number | bigint>, "result">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "items": Uint8Array[];
+}, bigint>>,
+    readNextTxin: {"name":"read-next-txin","access":"read_only","args":[{"name":"ignored","type":"bool"},{"name":"result","type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"remaining","type":"uint128"},{"name":"txins","type":{"list":{"type":{"tuple":[{"name":"outpoint","type":{"tuple":[{"name":"hash","type":{"buffer":{"length":32}}},{"name":"index","type":"uint128"}]}},{"name":"scriptSig","type":{"buffer":{"length":256}}},{"name":"sequence","type":"uint128"}]},"length":8}}}]},"error":"uint128"}}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"remaining","type":"uint128"},{"name":"txins","type":{"list":{"type":{"tuple":[{"name":"outpoint","type":{"tuple":[{"name":"hash","type":{"buffer":{"length":32}}},{"name":"index","type":"uint128"}]}},{"name":"scriptSig","type":{"buffer":{"length":256}}},{"name":"sequence","type":"uint128"}]},"length":8}}}]},"error":"uint128"}}}} as TypedAbiFunction<[ignored: TypedAbiArg<boolean, "ignored">, result: TypedAbiArg<Response<{
+  "ctx": {
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+};
+  "remaining": number | bigint;
+  "txins": {
+  "outpoint": {
+  "hash": Uint8Array;
+  "index": number | bigint;
+};
+  "scriptSig": Uint8Array;
+  "sequence": number | bigint;
+}[];
+}, number | bigint>, "result">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "remaining": bigint;
+  "txins": {
+  "outpoint": {
+  "hash": Uint8Array;
+  "index": bigint;
+};
+  "scriptSig": Uint8Array;
+  "sequence": bigint;
+}[];
+}, bigint>>,
+    readNextTxout: {"name":"read-next-txout","access":"read_only","args":[{"name":"ignored","type":"bool"},{"name":"result","type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"txouts","type":{"list":{"type":{"tuple":[{"name":"scriptPubKey","type":{"buffer":{"length":128}}},{"name":"value","type":"uint128"}]},"length":8}}}]},"error":"uint128"}}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"txouts","type":{"list":{"type":{"tuple":[{"name":"scriptPubKey","type":{"buffer":{"length":128}}},{"name":"value","type":"uint128"}]},"length":8}}}]},"error":"uint128"}}}} as TypedAbiFunction<[ignored: TypedAbiArg<boolean, "ignored">, result: TypedAbiArg<Response<{
+  "ctx": {
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+};
+  "txouts": {
+  "scriptPubKey": Uint8Array;
+  "value": number | bigint;
+}[];
+}, number | bigint>, "result">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "txouts": {
+  "scriptPubKey": Uint8Array;
+  "value": bigint;
+}[];
+}, bigint>>,
+    readNextWitness: {"name":"read-next-witness","access":"read_only","args":[{"name":"ignored","type":"bool"},{"name":"result","type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"witnesses","type":{"list":{"type":{"list":{"type":{"buffer":{"length":128}},"length":8}},"length":8}}}]},"error":"uint128"}}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"witnesses","type":{"list":{"type":{"list":{"type":{"buffer":{"length":128}},"length":8}},"length":8}}}]},"error":"uint128"}}}} as TypedAbiFunction<[ignored: TypedAbiArg<boolean, "ignored">, result: TypedAbiArg<Response<{
+  "ctx": {
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+};
+  "witnesses": Uint8Array[][];
+}, number | bigint>, "result">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "witnesses": Uint8Array[][];
+}, bigint>>,
+    readTxins: {"name":"read-txins","access":"read_only","args":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"remaining","type":"uint128"},{"name":"txins","type":{"list":{"type":{"tuple":[{"name":"outpoint","type":{"tuple":[{"name":"hash","type":{"buffer":{"length":32}}},{"name":"index","type":"uint128"}]}},{"name":"scriptSig","type":{"buffer":{"length":256}}},{"name":"sequence","type":"uint128"}]},"length":8}}}]},"error":"uint128"}}}} as TypedAbiFunction<[ctx: TypedAbiArg<{
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+}, "ctx">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "remaining": bigint;
+  "txins": {
+  "outpoint": {
+  "hash": Uint8Array;
+  "index": bigint;
+};
+  "scriptSig": Uint8Array;
+  "sequence": bigint;
+}[];
+}, bigint>>,
+    readTxouts: {"name":"read-txouts","access":"read_only","args":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"txouts","type":{"list":{"type":{"tuple":[{"name":"scriptPubKey","type":{"buffer":{"length":128}}},{"name":"value","type":"uint128"}]},"length":8}}}]},"error":"uint128"}}}} as TypedAbiFunction<[ctx: TypedAbiArg<{
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+}, "ctx">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "txouts": {
+  "scriptPubKey": Uint8Array;
+  "value": bigint;
+}[];
+}, bigint>>,
+    readUint16: {"name":"read-uint16","access":"read_only","args":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"uint16","type":"uint128"}]},"error":"uint128"}}}} as TypedAbiFunction<[ctx: TypedAbiArg<{
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+}, "ctx">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "uint16": bigint;
+}, bigint>>,
+    readUint32: {"name":"read-uint32","access":"read_only","args":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"uint32","type":"uint128"}]},"error":"uint128"}}}} as TypedAbiFunction<[ctx: TypedAbiArg<{
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+}, "ctx">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "uint32": bigint;
+}, bigint>>,
+    readUint64: {"name":"read-uint64","access":"read_only","args":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"uint64","type":"uint128"}]},"error":"uint128"}}}} as TypedAbiFunction<[ctx: TypedAbiArg<{
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+}, "ctx">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "uint64": bigint;
+}, bigint>>,
+    readUint8: {"name":"read-uint8","access":"read_only","args":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"uint8","type":"uint128"}]},"error":"uint128"}}}} as TypedAbiFunction<[ctx: TypedAbiArg<{
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+}, "ctx">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "uint8": bigint;
+}, bigint>>,
+    readVarint: {"name":"read-varint","access":"read_only","args":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"varint","type":"uint128"}]},"error":"uint128"}}}} as TypedAbiFunction<[ctx: TypedAbiArg<{
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+}, "ctx">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "varint": bigint;
+}, bigint>>,
+    readVarslice: {"name":"read-varslice","access":"read_only","args":[{"name":"old-ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"varslice","type":{"buffer":{"length":4096}}}]},"error":"uint128"}}}} as TypedAbiFunction<[oldCtx: TypedAbiArg<{
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+}, "oldCtx">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "varslice": Uint8Array;
+}, bigint>>,
+    readWitnesses: {"name":"read-witnesses","access":"read_only","args":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"num-txins","type":"uint128"}],"outputs":{"type":{"response":{"ok":{"tuple":[{"name":"ctx","type":{"tuple":[{"name":"index","type":"uint128"},{"name":"txbuff","type":{"buffer":{"length":4096}}}]}},{"name":"witnesses","type":{"list":{"type":{"list":{"type":{"buffer":{"length":128}},"length":8}},"length":8}}}]},"error":"uint128"}}}} as TypedAbiFunction<[ctx: TypedAbiArg<{
+  "index": number | bigint;
+  "txbuff": Uint8Array;
+}, "ctx">, numTxins: TypedAbiArg<number | bigint, "numTxins">], Response<{
+  "ctx": {
+  "index": bigint;
+  "txbuff": Uint8Array;
+};
+  "witnesses": Uint8Array[][];
+}, bigint>>,
+    reverseBuff32: {"name":"reverse-buff32","access":"read_only","args":[{"name":"input","type":{"buffer":{"length":32}}}],"outputs":{"type":{"buffer":{"length":32}}}} as TypedAbiFunction<[input: TypedAbiArg<Uint8Array, "input">], Uint8Array>,
+    verifyBlockHeader: {"name":"verify-block-header","access":"read_only","args":[{"name":"headerbuff","type":{"buffer":{"length":80}}},{"name":"expected-block-height","type":"uint128"}],"outputs":{"type":"bool"}} as TypedAbiFunction<[headerbuff: TypedAbiArg<Uint8Array, "headerbuff">, expectedBlockHeight: TypedAbiArg<number | bigint, "expectedBlockHeight">], boolean>,
+    verifyMerkleProof: {"name":"verify-merkle-proof","access":"read_only","args":[{"name":"reversed-txid","type":{"buffer":{"length":32}}},{"name":"merkle-root","type":{"buffer":{"length":32}}},{"name":"proof","type":{"tuple":[{"name":"hashes","type":{"list":{"type":{"buffer":{"length":32}},"length":14}}},{"name":"tree-depth","type":"uint128"},{"name":"tx-index","type":"uint128"}]}}],"outputs":{"type":{"response":{"ok":"bool","error":"uint128"}}}} as TypedAbiFunction<[reversedTxid: TypedAbiArg<Uint8Array, "reversedTxid">, merkleRoot: TypedAbiArg<Uint8Array, "merkleRoot">, proof: TypedAbiArg<{
+  "hashes": Uint8Array[];
+  "treeDepth": number | bigint;
+  "txIndex": number | bigint;
+}, "proof">], Response<boolean, bigint>>,
+    wasSegwitTxMinedCompact: {"name":"was-segwit-tx-mined-compact","access":"read_only","args":[{"name":"height","type":"uint128"},{"name":"wtx","type":{"buffer":{"length":4096}}},{"name":"header","type":{"buffer":{"length":80}}},{"name":"tx-index","type":"uint128"},{"name":"tree-depth","type":"uint128"},{"name":"wproof","type":{"list":{"type":{"buffer":{"length":32}},"length":14}}},{"name":"witness-merkle-root","type":{"buffer":{"length":32}}},{"name":"witness-reserved-value","type":{"buffer":{"length":32}}},{"name":"ctx","type":{"buffer":{"length":1024}}},{"name":"cproof","type":{"list":{"type":{"buffer":{"length":32}},"length":14}}}],"outputs":{"type":{"response":{"ok":{"buffer":{"length":32}},"error":"uint128"}}}} as TypedAbiFunction<[height: TypedAbiArg<number | bigint, "height">, wtx: TypedAbiArg<Uint8Array, "wtx">, header: TypedAbiArg<Uint8Array, "header">, txIndex: TypedAbiArg<number | bigint, "txIndex">, treeDepth: TypedAbiArg<number | bigint, "treeDepth">, wproof: TypedAbiArg<Uint8Array[], "wproof">, witnessMerkleRoot: TypedAbiArg<Uint8Array, "witnessMerkleRoot">, witnessReservedValue: TypedAbiArg<Uint8Array, "witnessReservedValue">, ctx: TypedAbiArg<Uint8Array, "ctx">, cproof: TypedAbiArg<Uint8Array[], "cproof">], Response<Uint8Array, bigint>>,
+    wasTxMinedCompact: {"name":"was-tx-mined-compact","access":"read_only","args":[{"name":"height","type":"uint128"},{"name":"tx","type":{"buffer":{"length":4096}}},{"name":"header","type":{"buffer":{"length":80}}},{"name":"proof","type":{"tuple":[{"name":"hashes","type":{"list":{"type":{"buffer":{"length":32}},"length":14}}},{"name":"tree-depth","type":"uint128"},{"name":"tx-index","type":"uint128"}]}}],"outputs":{"type":{"response":{"ok":{"buffer":{"length":32}},"error":"uint128"}}}} as TypedAbiFunction<[height: TypedAbiArg<number | bigint, "height">, tx: TypedAbiArg<Uint8Array, "tx">, header: TypedAbiArg<Uint8Array, "header">, proof: TypedAbiArg<{
+  "hashes": Uint8Array[];
+  "treeDepth": number | bigint;
+  "txIndex": number | bigint;
+}, "proof">], Response<Uint8Array, bigint>>
+  },
+  "maps": {
+    
+  },
+  "variables": {
+    ERR_BAD_HEADER: {
+  name: 'ERR-BAD-HEADER',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>,
+    ERR_HEADER_HEIGHT_MISMATCH: {
+  name: 'ERR-HEADER-HEIGHT-MISMATCH',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>,
+    ERR_INVALID_COMMITMENT: {
+  name: 'ERR-INVALID-COMMITMENT',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>,
+    ERR_INVALID_MERKLE_PROOF: {
+  name: 'ERR-INVALID-MERKLE-PROOF',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>,
+    ERR_LEFTOVER_DATA: {
+  name: 'ERR-LEFTOVER-DATA',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>,
+    ERR_NOT_SEGWIT_TRANSACTION: {
+  name: 'ERR-NOT-SEGWIT-TRANSACTION',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>,
+    ERR_OUT_OF_BOUNDS: {
+  name: 'ERR-OUT-OF-BOUNDS',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>,
+    ERR_PROOF_TOO_SHORT: {
+  name: 'ERR-PROOF-TOO-SHORT',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>,
+    ERR_TOO_MANY_TXINS: {
+  name: 'ERR-TOO-MANY-TXINS',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>,
+    ERR_TOO_MANY_TXOUTS: {
+  name: 'ERR-TOO-MANY-TXOUTS',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>,
+    ERR_TOO_MANY_WITNESSES: {
+  name: 'ERR-TOO-MANY-WITNESSES',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>,
+    ERR_VARSLICE_TOO_LONG: {
+  name: 'ERR-VARSLICE-TOO-LONG',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>,
+    ERR_WITNESS_TX_NOT_IN_COMMITMENT: {
+  name: 'ERR-WITNESS-TX-NOT-IN-COMMITMENT',
+  type: 'uint128',
+  access: 'constant'
+} as TypedAbiVariable<bigint>
+  },
+  constants: {},
+  "non_fungible_tokens": [
+    
+  ],
+  "fungible_tokens":[],"epoch":"Epoch24","clarity_version":"Clarity2",
+  contractName: 'clarity-bitcoin-lib-v5',
+  }
+} as const;
+
+export const accounts = {"deployer":{"address":"ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM","balance":"100000000000000"},"faucet":{"address":"STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6","balance":"100000000000000"},"wallet_1":{"address":"ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5","balance":"100000000000000"},"wallet_2":{"address":"ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG","balance":"100000000000000"},"wallet_3":{"address":"ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC","balance":"100000000000000"},"wallet_4":{"address":"ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND","balance":"100000000000000"},"wallet_5":{"address":"ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB","balance":"100000000000000"},"wallet_6":{"address":"ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0","balance":"100000000000000"},"wallet_7":{"address":"ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ","balance":"100000000000000"},"wallet_8":{"address":"ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP","balance":"100000000000000"}} as const;
+
+export const identifiers = {"clarityBitcoinLibV5":"SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.clarity-bitcoin-lib-v5"} as const
+
+export const simnet = {
+  accounts,
+  contracts,
+  identifiers,
+} as const;
+
+
+export const deployments = {"clarityBitcoinLibV5":{"devnet":"ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.clarity-bitcoin-lib-v5","simnet":"SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.clarity-bitcoin-lib-v5","testnet":null,"mainnet":"SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.clarity-bitcoin-lib-v5"}} as const;
+
+export const project = {
+  contracts,
+  deployments,
+} as const;
+  

--- a/src/__vitests__/clarity-bitcoin-lib-v5.test.ts
+++ b/src/__vitests__/clarity-bitcoin-lib-v5.test.ts
@@ -1,0 +1,101 @@
+import { hexToBytes, projectFactory } from "@clarigen/core";
+import { describe, test } from "vitest";
+import { BitcoinRPCConfig, bitcoinTxProof } from "..";
+import { BitcoinRPC } from "../rpc";
+import { project } from "./clarigen-types";
+import { rov } from "@clarigen/test";
+
+const { clarityBitcoinLibV5 } = projectFactory(project, "simnet");
+
+describe("Clarity Bitcoin Lib v5 verification", () => {
+  // Using real Bitcoin transaction id from mainnet
+  const txId =
+    "bd725ba1fc3be138d2d62cd3ec4c7f55e2e33811ee1e5dbffd44e91686a233f3";
+  const rawTx =
+    "02000000000101695eb97b50eca9e08eb8fefec3b76eacae4795aaba529b5ff89829970b5fda2b0100000000fdffffff02e0c8100000000000160014da3337a038d08317ca6daf0ea1d377e4febb89995a111101000000001600140e105cbce363554cd67d77bfc1f50bb632b2c3fd0247304402201c7f73c5fccb4865335e8d72d927d68997452fb5e03260e65ac44f4f83b3aa22022024e26970fd2b616b57f604d92fd91e8d2e611650b2af3a84e670ff0074ccbc610121029e36010f142ece1a67893a5897b3b42f5b4f924ba35b1d94d84fc065c7786d7f46790d00";
+  const explorerApiTx = {
+    txid: "bd725ba1fc3be138d2d62cd3ec4c7f55e2e33811ee1e5dbffd44e91686a233f3",
+    hash: "9eeaa10649e8947fef767422788d210d4de44187ba810c411ebfc1f2316ac41a",
+    version: 2,
+    size: 222,
+    vsize: 141,
+    weight: 561,
+    locktime: 883014,
+    vin: [
+      {
+        txid: "2bda5f0b972998f85f9b52baaa9547aeac6eb7c3fefeb88ee0a9ec507bb95e69",
+        vout: 1,
+        scriptSig: {
+          asm: "",
+          hex: "",
+        },
+        txinwitness: [
+          "304402201c7f73c5fccb4865335e8d72d927d68997452fb5e03260e65ac44f4f83b3aa22022024e26970fd2b616b57f604d92fd91e8d2e611650b2af3a84e670ff0074ccbc6101",
+          "029e36010f142ece1a67893a5897b3b42f5b4f924ba35b1d94d84fc065c7786d7f",
+        ],
+        sequence: 4294967293,
+      },
+    ],
+    vout: [
+      {
+        value: 0.011,
+        n: 0,
+        scriptPubKey: {
+          asm: "0 da3337a038d08317ca6daf0ea1d377e4febb8999",
+          desc: "addr(bc1qmgen0gpc6zp30jnd4u82r5mhunlthzveu747zx)#7w9pt5f3",
+          hex: "0014da3337a038d08317ca6daf0ea1d377e4febb8999",
+          address: "bc1qmgen0gpc6zp30jnd4u82r5mhunlthzveu747zx",
+          type: "witness_v0_keyhash",
+        },
+      },
+      {
+        value: 0.1789577,
+        n: 1,
+        scriptPubKey: {
+          asm: "0 0e105cbce363554cd67d77bfc1f50bb632b2c3fd",
+          desc: "addr(bc1qpcg9e08rvd25e4naw7luragtkcet9sla7nzjvs)#5cndh8w4",
+          hex: "00140e105cbce363554cd67d77bfc1f50bb632b2c3fd",
+          address: "bc1qpcg9e08rvd25e4naw7luragtkcet9sla7nzjvs",
+          type: "witness_v0_keyhash",
+        },
+      },
+    ],
+    hex: "02000000000101695eb97b50eca9e08eb8fefec3b76eacae4795aaba529b5ff89829970b5fda2b0100000000fdffffff02e0c8100000000000160014da3337a038d08317ca6daf0ea1d377e4febb89995a111101000000001600140e105cbce363554cd67d77bfc1f50bb632b2c3fd0247304402201c7f73c5fccb4865335e8d72d927d68997452fb5e03260e65ac44f4f83b3aa22022024e26970fd2b616b57f604d92fd91e8d2e611650b2af3a84e670ff0074ccbc610121029e36010f142ece1a67893a5897b3b42f5b4f924ba35b1d94d84fc065c7786d7f46790d00",
+    blockhash:
+      "00000000000000000000ce2bb7d4eb76a893c41b480ce1617c5f2094221451e3",
+    confirmations: 38,
+    time: 1739100517,
+    blocktime: 1739100517,
+  };
+
+  const blockHeight = 883016;
+  const stacksBlockHeight = 586955;
+  const rpcConfig: BitcoinRPCConfig = {
+    url: "http://localhost:8332",
+  };
+
+  test("verify tx using Stacks", async () => {
+    const proof = await bitcoinTxProof(txId, blockHeight, rpcConfig);
+    const txObject = await new BitcoinRPC(rpcConfig).call("getrawtransaction", [
+      txId,
+    ]);
+    console.log(proof);
+    console.log(txObject);
+
+    const submission = rov(
+      clarityBitcoinLibV5.wasSegwitTxMinedCompact(
+        stacksBlockHeight,
+        hexToBytes(rawTx),
+        hexToBytes(proof.blockHeader),
+        proof.txIndex,
+        proof.merkleProofDepth,
+        proof.witnessMerkleProofArray,
+        hexToBytes(proof.witnessMerkleRoot),
+        hexToBytes(proof.witnessReservedValue),
+        hexToBytes(proof.coinbaseTransaction),
+        proof.coinbaseMerkleProofArray
+      )
+    );
+    console.log({ submission });
+  });
+}, 100_000);

--- a/src/__vitests__/clarity-bitcoin-lib-v5.test.ts
+++ b/src/__vitests__/clarity-bitcoin-lib-v5.test.ts
@@ -10,66 +10,70 @@ const { clarityBitcoinLibV5 } = projectFactory(project, "simnet");
 describe("Clarity Bitcoin Lib v5 verification", () => {
   // Using real Bitcoin transaction id from mainnet
   const txId =
-    "bd725ba1fc3be138d2d62cd3ec4c7f55e2e33811ee1e5dbffd44e91686a233f3";
+    "b8900af7ce01917fa9640ddcb8e3b985cc5602ba4d8d47bd702a1cfd92a54b9c";
   const rawTx =
-    "02000000000101695eb97b50eca9e08eb8fefec3b76eacae4795aaba529b5ff89829970b5fda2b0100000000fdffffff02e0c8100000000000160014da3337a038d08317ca6daf0ea1d377e4febb89995a111101000000001600140e105cbce363554cd67d77bfc1f50bb632b2c3fd0247304402201c7f73c5fccb4865335e8d72d927d68997452fb5e03260e65ac44f4f83b3aa22022024e26970fd2b616b57f604d92fd91e8d2e611650b2af3a84e670ff0074ccbc610121029e36010f142ece1a67893a5897b3b42f5b4f924ba35b1d94d84fc065c7786d7f46790d00";
+    "0200000000010107d234bcb9763403fcb5c804d9a38d5cfccd9cb80cd46e12057b23ced1e2545e0000000000fdffffff025e570000000000001600142211d02a6f89d49f274384d7cfff0be15693fba29c079b1000000000160014192e80ed2c7c412bdc2a6c8f371d15cb90f3c85b0247304402200a9b5884eeef9011b5d30251d39540d7c164c0fb60242e1969a30de158f66abb02201c77b55fbd9fdeb9d8e4fee995723803ad7d7f4f585def9eb351512c55d2c9a1012103b01bd095f648ea829f000207087f16622431077bb5cc0875225ada601375c88500000000";
   const explorerApiTx = {
-    txid: "bd725ba1fc3be138d2d62cd3ec4c7f55e2e33811ee1e5dbffd44e91686a233f3",
-    hash: "9eeaa10649e8947fef767422788d210d4de44187ba810c411ebfc1f2316ac41a",
+    txid: "b8900af7ce01917fa9640ddcb8e3b985cc5602ba4d8d47bd702a1cfd92a54b9c",
+    hash: "fadeb6517b1fe9c31fcd96d56b2f3e90d1013cd9bd590d458c54ae6cd8745687",
     version: 2,
     size: 222,
     vsize: 141,
     weight: 561,
-    locktime: 883014,
+    locktime: 0,
     vin: [
       {
-        txid: "2bda5f0b972998f85f9b52baaa9547aeac6eb7c3fefeb88ee0a9ec507bb95e69",
-        vout: 1,
+        txid: "5e54e2d1ce237b05126ed40cb89ccdfc5c8da3d904c8b5fc033476b9bc34d207",
+        vout: 0,
         scriptSig: {
           asm: "",
           hex: "",
         },
         txinwitness: [
-          "304402201c7f73c5fccb4865335e8d72d927d68997452fb5e03260e65ac44f4f83b3aa22022024e26970fd2b616b57f604d92fd91e8d2e611650b2af3a84e670ff0074ccbc6101",
-          "029e36010f142ece1a67893a5897b3b42f5b4f924ba35b1d94d84fc065c7786d7f",
+          "304402200a9b5884eeef9011b5d30251d39540d7c164c0fb60242e1969a30de158f66abb02201c77b55fbd9fdeb9d8e4fee995723803ad7d7f4f585def9eb351512c55d2c9a101",
+          "03b01bd095f648ea829f000207087f16622431077bb5cc0875225ada601375c885",
         ],
         sequence: 4294967293,
       },
     ],
     vout: [
       {
-        value: 0.011,
+        value: 0.00022366,
         n: 0,
         scriptPubKey: {
-          asm: "0 da3337a038d08317ca6daf0ea1d377e4febb8999",
-          desc: "addr(bc1qmgen0gpc6zp30jnd4u82r5mhunlthzveu747zx)#7w9pt5f3",
-          hex: "0014da3337a038d08317ca6daf0ea1d377e4febb8999",
-          address: "bc1qmgen0gpc6zp30jnd4u82r5mhunlthzveu747zx",
+          asm: "0 2211d02a6f89d49f274384d7cfff0be15693fba2",
+          desc: "addr(bc1qyggaq2n0382f7f6rsntullctu9tf87azqjjln6)#k4tk58qf",
+          hex: "00142211d02a6f89d49f274384d7cfff0be15693fba2",
+          address: "bc1qyggaq2n0382f7f6rsntullctu9tf87azqjjln6",
           type: "witness_v0_keyhash",
         },
       },
       {
-        value: 0.1789577,
+        value: 2.78595484,
         n: 1,
         scriptPubKey: {
-          asm: "0 0e105cbce363554cd67d77bfc1f50bb632b2c3fd",
-          desc: "addr(bc1qpcg9e08rvd25e4naw7luragtkcet9sla7nzjvs)#5cndh8w4",
-          hex: "00140e105cbce363554cd67d77bfc1f50bb632b2c3fd",
-          address: "bc1qpcg9e08rvd25e4naw7luragtkcet9sla7nzjvs",
+          asm: "0 192e80ed2c7c412bdc2a6c8f371d15cb90f3c85b",
+          desc: "addr(bc1qryhgpmfv03qjhhp2dj8nw8g4ewg08jzmgy3cyx)#rumqegaa",
+          hex: "0014192e80ed2c7c412bdc2a6c8f371d15cb90f3c85b",
+          address: "bc1qryhgpmfv03qjhhp2dj8nw8g4ewg08jzmgy3cyx",
           type: "witness_v0_keyhash",
         },
       },
     ],
-    hex: "02000000000101695eb97b50eca9e08eb8fefec3b76eacae4795aaba529b5ff89829970b5fda2b0100000000fdffffff02e0c8100000000000160014da3337a038d08317ca6daf0ea1d377e4febb89995a111101000000001600140e105cbce363554cd67d77bfc1f50bb632b2c3fd0247304402201c7f73c5fccb4865335e8d72d927d68997452fb5e03260e65ac44f4f83b3aa22022024e26970fd2b616b57f604d92fd91e8d2e611650b2af3a84e670ff0074ccbc610121029e36010f142ece1a67893a5897b3b42f5b4f924ba35b1d94d84fc065c7786d7f46790d00",
+    hex: "0200000000010107d234bcb9763403fcb5c804d9a38d5cfccd9cb80cd46e12057b23ced1e2545e0000000000fdffffff025e570000000000001600142211d02a6f89d49f274384d7cfff0be15693fba29c079b1000000000160014192e80ed2c7c412bdc2a6c8f371d15cb90f3c85b0247304402200a9b5884eeef9011b5d30251d39540d7c164c0fb60242e1969a30de158f66abb02201c77b55fbd9fdeb9d8e4fee995723803ad7d7f4f585def9eb351512c55d2c9a1012103b01bd095f648ea829f000207087f16622431077bb5cc0875225ada601375c88500000000",
     blockhash:
-      "00000000000000000000ce2bb7d4eb76a893c41b480ce1617c5f2094221451e3",
-    confirmations: 38,
-    time: 1739100517,
-    blocktime: 1739100517,
+      "000000000000000000012682cbf06d8e9ea176f52682a743896dbbf0774f09bb",
+    confirmations: 191,
+    time: 1739016401,
+    blocktime: 1739016401,
   };
 
-  const blockHeight = 883016;
-  const stacksBlockHeight = 586955;
+  const blockHeight = 882877;
+  const stacksBlockHeight = 581021; // first stacks block after 882876 but anchored to 882878
+  const coinbaseTxId =
+    "04d599b2aa305544933aba815154a86fd109294990b034c6ab2f78e041e91eb7";
+  const coinbaseTxRaw =
+    "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff630348790d046791a8677c204d415241204d61646520696e2055534120f09f87baf09f87b8207c763032fabe6d6d38d85a584baaf6fb55294f152cb402c8781f48aaa07a0b109146ef14269264530100000000000000139c9f06fd00cf300000ffffffffffffffff027d96b412000000001976a9142fc701e2049ee4957b07134b6c1d771dd5a96b2188ac0000000000000000266a24aa21a9ed2e1fb03d8dff026a9b7422846873b27330dcb66b770fd64d2f3960efb2ce1b840120000000000000000000000000000000000000000000000000000000000000000088bc2c16";
   const rpcConfig: BitcoinRPCConfig = {
     url: "http://localhost:8332",
   };
@@ -81,6 +85,32 @@ describe("Clarity Bitcoin Lib v5 verification", () => {
     ]);
     console.log(proof);
     console.log(txObject);
+    console.log("cproof", proof.coinbaseMerkleProofArray);
+
+    const header = rov(
+      clarityBitcoinLibV5.verifyBlockHeader(
+        hexToBytes(proof.blockHeader),
+        blockHeight
+      )
+    );
+    console.log({ header });
+
+    expect(header).toBe(true);
+
+    const valid = rov(
+      clarityBitcoinLibV5.wasTxMinedCompact(
+        blockHeight,
+        hexToBytes(proof.coinbaseTransaction),
+        hexToBytes(proof.blockHeader),
+        {
+          hashes: proof.coinbaseMerkleProofArray,
+          txIndex: 0,
+          treeDepth: proof.coinbaseMerkleProofArray.length,
+        }
+      )
+    );
+
+    console.log({ valid });
 
     const submission = rov(
       clarityBitcoinLibV5.wasSegwitTxMinedCompact(

--- a/src/__vitests__/clarity-bitcoin-lib-v5.test.ts
+++ b/src/__vitests__/clarity-bitcoin-lib-v5.test.ts
@@ -1,5 +1,5 @@
 import { hexToBytes, projectFactory } from "@clarigen/core";
-import { describe, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { BitcoinRPCConfig, bitcoinTxProof } from "..";
 import { BitcoinRPC } from "../rpc";
 import { project } from "./clarigen-types";
@@ -10,76 +10,20 @@ const { clarityBitcoinLibV5 } = projectFactory(project, "simnet");
 describe("Clarity Bitcoin Lib v5 verification", () => {
   // Using real Bitcoin transaction id from mainnet
   const txId =
-    "b8900af7ce01917fa9640ddcb8e3b985cc5602ba4d8d47bd702a1cfd92a54b9c";
-  const rawTx =
-    "0200000000010107d234bcb9763403fcb5c804d9a38d5cfccd9cb80cd46e12057b23ced1e2545e0000000000fdffffff025e570000000000001600142211d02a6f89d49f274384d7cfff0be15693fba29c079b1000000000160014192e80ed2c7c412bdc2a6c8f371d15cb90f3c85b0247304402200a9b5884eeef9011b5d30251d39540d7c164c0fb60242e1969a30de158f66abb02201c77b55fbd9fdeb9d8e4fee995723803ad7d7f4f585def9eb351512c55d2c9a1012103b01bd095f648ea829f000207087f16622431077bb5cc0875225ada601375c88500000000";
-  const explorerApiTx = {
-    txid: "b8900af7ce01917fa9640ddcb8e3b985cc5602ba4d8d47bd702a1cfd92a54b9c",
-    hash: "fadeb6517b1fe9c31fcd96d56b2f3e90d1013cd9bd590d458c54ae6cd8745687",
-    version: 2,
-    size: 222,
-    vsize: 141,
-    weight: 561,
-    locktime: 0,
-    vin: [
-      {
-        txid: "5e54e2d1ce237b05126ed40cb89ccdfc5c8da3d904c8b5fc033476b9bc34d207",
-        vout: 0,
-        scriptSig: {
-          asm: "",
-          hex: "",
-        },
-        txinwitness: [
-          "304402200a9b5884eeef9011b5d30251d39540d7c164c0fb60242e1969a30de158f66abb02201c77b55fbd9fdeb9d8e4fee995723803ad7d7f4f585def9eb351512c55d2c9a101",
-          "03b01bd095f648ea829f000207087f16622431077bb5cc0875225ada601375c885",
-        ],
-        sequence: 4294967293,
-      },
-    ],
-    vout: [
-      {
-        value: 0.00022366,
-        n: 0,
-        scriptPubKey: {
-          asm: "0 2211d02a6f89d49f274384d7cfff0be15693fba2",
-          desc: "addr(bc1qyggaq2n0382f7f6rsntullctu9tf87azqjjln6)#k4tk58qf",
-          hex: "00142211d02a6f89d49f274384d7cfff0be15693fba2",
-          address: "bc1qyggaq2n0382f7f6rsntullctu9tf87azqjjln6",
-          type: "witness_v0_keyhash",
-        },
-      },
-      {
-        value: 2.78595484,
-        n: 1,
-        scriptPubKey: {
-          asm: "0 192e80ed2c7c412bdc2a6c8f371d15cb90f3c85b",
-          desc: "addr(bc1qryhgpmfv03qjhhp2dj8nw8g4ewg08jzmgy3cyx)#rumqegaa",
-          hex: "0014192e80ed2c7c412bdc2a6c8f371d15cb90f3c85b",
-          address: "bc1qryhgpmfv03qjhhp2dj8nw8g4ewg08jzmgy3cyx",
-          type: "witness_v0_keyhash",
-        },
-      },
-    ],
-    hex: "0200000000010107d234bcb9763403fcb5c804d9a38d5cfccd9cb80cd46e12057b23ced1e2545e0000000000fdffffff025e570000000000001600142211d02a6f89d49f274384d7cfff0be15693fba29c079b1000000000160014192e80ed2c7c412bdc2a6c8f371d15cb90f3c85b0247304402200a9b5884eeef9011b5d30251d39540d7c164c0fb60242e1969a30de158f66abb02201c77b55fbd9fdeb9d8e4fee995723803ad7d7f4f585def9eb351512c55d2c9a1012103b01bd095f648ea829f000207087f16622431077bb5cc0875225ada601375c88500000000",
-    blockhash:
-      "000000000000000000012682cbf06d8e9ea176f52682a743896dbbf0774f09bb",
-    confirmations: 191,
-    time: 1739016401,
-    blocktime: 1739016401,
-  };
+    "c1de234c01ecc47906117d012865ce3dabbbb081dc0309a74dbbae45e427aadc";
 
-  const blockHeight = 882877;
-  const stacksBlockHeight = 581021; // first stacks block after 882876 but anchored to 882878
-  const coinbaseTxId =
-    "04d599b2aa305544933aba815154a86fd109294990b034c6ab2f78e041e91eb7";
-  const coinbaseTxRaw =
-    "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff630348790d046791a8677c204d415241204d61646520696e2055534120f09f87baf09f87b8207c763032fabe6d6d38d85a584baaf6fb55294f152cb402c8781f48aaa07a0b109146ef14269264530100000000000000139c9f06fd00cf300000ffffffffffffffff027d96b412000000001976a9142fc701e2049ee4957b07134b6c1d771dd5a96b2188ac0000000000000000266a24aa21a9ed2e1fb03d8dff026a9b7422846873b27330dcb66b770fd64d2f3960efb2ce1b840120000000000000000000000000000000000000000000000000000000000000000088bc2c16";
+  const rawTx =
+    "02000000000101f6e86a2b938453e199836ad4e2ba751c5ded24f4e1c2934b3434cd00f9bce61d0100000000fdffffff02856e00000000000017a914c5beca99b2b4c558b297ed9134142f4a3873f4e987d0b8390100000000160014b84ef1e7e398d56fa88a356df3139ff997114f040247304402205edad21077602766ffbce1276b6a3b69577a521b28dc18d8062303723ac91cc802200ec9ea72f62069b1e5817a999fa3d31acf0f655a159691feb8161fb33b93f3fa012103997651fec067eda2c430bfe548f65575737c9b892d8b529ae9dc0dfcb5c5898a00000000";
+  const blockHeight = 883230;
+  const stacksBlockHeight = 595050; // first stacks block after 882876 but anchored to 882878
   const rpcConfig: BitcoinRPCConfig = {
     url: "http://localhost:8332",
   };
 
   test("verify tx using Stacks", async () => {
     const proof = await bitcoinTxProof(txId, blockHeight, rpcConfig);
+    console.log(proof.witnessMerkleProof);
+
     const txObject = await new BitcoinRPC(rpcConfig).call("getrawtransaction", [
       txId,
     ]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,8 +141,9 @@ export async function bitcoinTxProof(
       }));
 
       debug('Calculating witness merkle proof...');
-      const { proof, root } = calculateWitnessMerkleProof(txs, txIndex);
-      debug('Witness merkle root:', root.toString('hex'));
+      const { proof, root: calculatedRoot } = calculateWitnessMerkleProof(txs, txIndex);
+      root = calculatedRoot.toString('hex');
+      debug('Witness merkle root:', root);
       debug('Witness proof steps:', proof.map(step => ({
         position: step.position,
         hash: step.data.toString('hex')

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,8 @@ export async function bitcoinTxProof(
 
   // For single-tx blocks, witness merkle proof is empty
   let witnessMerkleProof = '';
+  let witnessMerkleProofArray: Uint8Array<ArrayBuffer>[] = [];
+  let root = "";
   if (block.tx.length > 1 && txIndex !== 0) {
     debug('Calculating witness merkle data...');
     try {
@@ -154,6 +156,7 @@ export async function bitcoinTxProof(
         witnessMerkleProof = proof
           .map(step => step.data.toString('hex'))
           .join('');
+        witnessMerkleProofArray = proof.map(step => new Uint8Array(step.data));
         debug('Witness merkle proof hex:', witnessMerkleProof);
       }
     } catch (error) {
@@ -175,10 +178,13 @@ export async function bitcoinTxProof(
     blockHeader,
     txIndex,
     merkleProofDepth: Math.ceil(Math.log2(Math.max(block.tx.length, 2))),
+    witnessMerkleRoot: root,
     witnessMerkleProof,
+    witnessMerkleProofArray,
     witnessReservedValue: '0000000000000000000000000000000000000000000000000000000000000000',
     coinbaseTransaction: coinbaseTx.hex,
-    coinbaseMerkleProof: merkleProofHex
+    coinbaseMerkleProof: merkleProofHex,
+    coinbaseMerkleProofArray: merkleProof.map(step => new Uint8Array(step.data))
   };
 
   debug('Final result:', {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,11 @@ export interface TxProofResult {
   blockHeader: string;
   txIndex: number;
   merkleProofDepth: number;
+  witnessMerkleRoot: string;
   witnessMerkleProof: string;
+  witnessMerkleProofArray: Uint8Array<ArrayBuffer>[];
   witnessReservedValue: string;
   coinbaseTransaction: string;
   coinbaseMerkleProof: string;
+  coinbaseMerkleProofArray: Uint8Array<ArrayBuffer>[];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,25 @@
 {
   "compilerOptions": {
-    "target": "es2020",
-    "module": "commonjs",
-    "declaration": true,
-    "outDir": "./dist",
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ESNext"],
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+
     "strict": true,
-    "esModuleInterop": true,
-    "lib": ["es2020", "dom"],
-    "moduleResolution": "node"
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "node_modules/@hirosystems/clarinet-sdk/vitest-helpers/src",
+    "tests"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true
   },
   "include": [
     "node_modules/@hirosystems/clarinet-sdk/vitest-helpers/src",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,43 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from "vite";
+import {
+  vitestSetupFilePath,
+  getClarinetVitestsArgv,
+} from "@hirosystems/clarinet-sdk/vitest";
+
+/*
+  In this file, Vitest is configured so that it works seamlessly with Clarinet and the Simnet.
+
+  The `vitest-environment-clarinet` will initialise the clarinet-sdk
+  and make the `simnet` object available globally in the test files.
+
+  `vitestSetupFilePath` points to a file in the `@hirosystems/clarinet-sdk` package that does two things:
+    - run `before` hooks to initialize the simnet and `after` hooks to collect costs and coverage reports.
+    - load custom vitest matchers to work with Clarity values (such as `expect(...).toBeUint()`)
+
+  The `getClarinetVitestsArgv()` will parse options passed to the command `vitest run --`
+    - vitest run -- --manifest ./Clarinet.toml  # pass a custom path
+    - vitest run -- --coverage --costs          # collect coverage and cost reports
+*/
+
+export default defineConfig({
+  test: {
+    environment: "clarinet", // use vitest-environment-clarinet
+    pool: "forks",
+    poolOptions: {
+      threads: { singleThread: true },
+      forks: { singleFork: true },
+    },
+    setupFiles: [
+      vitestSetupFilePath,
+      // custom setup files can be added here
+    ],
+    environmentOptions: {
+      clarinet: {
+        ...getClarinetVitestsArgv(),
+        // add or override options
+      },
+    },
+  },
+});


### PR DESCRIPTION
This PR
* adds a test for using bitcoin-tx-proof with clarity-bitcoin-lib-v5

Test runs with vitest
`npm test:stacks`